### PR TITLE
Combined dependencies PR

### DIFF
--- a/dash-app/requirements.txt
+++ b/dash-app/requirements.txt
@@ -9,7 +9,7 @@ Flask-Compress==1.10.1
 itsdangerous==2.0.1
 Jinja2==3.0.2
 MarkupSafe==2.0.1
-numpy==1.21.2
+numpy==1.22.0
 pandas==1.3.3
 plotly==5.3.1
 python-dateutil==2.8.2

--- a/dash-bikeshare/requirements.txt
+++ b/dash-bikeshare/requirements.txt
@@ -12,7 +12,7 @@ idna==3.2
 itsdangerous==2.0.1
 Jinja2==3.0.2
 MarkupSafe==2.0.1
-numpy==1.21.2
+numpy==1.22.0
 pandas==1.3.3
 patsy==0.5.2
 plotly==5.3.1

--- a/fastapi-stock/requirements.txt
+++ b/fastapi-stock/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.4.1
 click==8.0.1
 fastapi==0.66.0
 h11==0.12.0
-numpy==1.21.0
+numpy==1.22.0
 pandas==1.3.0
 pydantic==1.8.2
 python-dateutil==2.8.2

--- a/flask-restx/requirements.txt
+++ b/flask-restx/requirements.txt
@@ -8,7 +8,7 @@ Jinja2==3.0.2
 joblib==1.1.0
 jsonschema==4.0.1
 MarkupSafe==2.0.1
-numpy==1.21.2
+numpy==1.22.0
 pandas==1.3.3
 pyrsistent==0.18.0
 python-dateutil==2.8.2

--- a/flask-sentiment-analysis-api/requirements.txt
+++ b/flask-sentiment-analysis-api/requirements.txt
@@ -10,7 +10,7 @@ itsdangerous==2.0.1
 Jinja2==3.0.2
 MarkupSafe==2.0.1
 murmurhash==1.0.5
-numpy==1.21.2
+numpy==1.22.0
 plac==1.1.3
 preshed==3.0.5
 requests==2.26.0

--- a/image-classifier/requirements.txt
+++ b/image-classifier/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2021.5.30
 charset-normalizer==2.0.6
 idna==3.2
-numpy==1.21.2
+numpy==1.22.0
 Pillow==9.0.1
 requests==2.26.0
 torch==1.9.1

--- a/jupyter-interactive-visualization/requirements.txt
+++ b/jupyter-interactive-visualization/requirements.txt
@@ -20,7 +20,7 @@ jupyter-core==4.8.1
 jupyterlab-pygments==0.1.2
 MarkupSafe==2.0.1
 matplotlib-inline==0.1.3
-mistune==0.8.4
+mistune==2.0.3
 nbclient==0.5.4
 nbconvert==6.2.0
 nbformat==5.1.3

--- a/jupyter-interactive-visualization/requirements.txt
+++ b/jupyter-interactive-visualization/requirements.txt
@@ -26,7 +26,7 @@ nbconvert==6.2.0
 nbformat==5.1.3
 nest-asyncio==1.5.1
 notebook==6.4.12
-numpy==1.21.2
+numpy==1.22.0
 packaging==21.0
 pandas==1.3.4
 pandocfilters==1.5.0

--- a/jupyter-static-visualization/requirements.txt
+++ b/jupyter-static-visualization/requirements.txt
@@ -22,7 +22,7 @@ kiwisolver==1.3.2
 MarkupSafe==2.0.1
 matplotlib==3.4.3
 matplotlib-inline==0.1.3
-mistune==0.8.4
+mistune==2.0.3
 nbclient==0.5.4
 nbconvert==6.2.0
 nbformat==5.1.3

--- a/jupyter-static-visualization/requirements.txt
+++ b/jupyter-static-visualization/requirements.txt
@@ -28,7 +28,7 @@ nbconvert==6.2.0
 nbformat==5.1.3
 nest-asyncio==1.5.1
 notebook==6.4.12
-numpy==1.21.2
+numpy==1.22.0
 packaging==21.0
 pandas==1.3.3
 pandocfilters==1.5.0

--- a/rmarkdown-notebook/requirements.txt
+++ b/rmarkdown-notebook/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.21.2
+numpy==1.22.0
 pandas==1.3.3
 python-dateutil==2.8.2
 pytz==2021.3

--- a/rmarkdown-static-visualization/requirements.txt
+++ b/rmarkdown-static-visualization/requirements.txt
@@ -1,7 +1,7 @@
 cycler==0.10.0
 kiwisolver==1.3.2
 matplotlib==3.4.3
-numpy==1.21.2
+numpy==1.22.0
 pandas==1.3.3
 Pillow==9.0.1
 pyparsing==2.4.7

--- a/sentiment-analysis-app/requirements.txt
+++ b/sentiment-analysis-app/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==2.0.6
 cymem==2.0.5
 idna==3.2
 murmurhash==1.0.5
-numpy==1.21.2
+numpy==1.22.0
 plac==1.1.3
 preshed==3.0.5
 requests==2.26.0

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -63,7 +63,7 @@ requests==2.26.0
 Send2Trash==1.8.0
 six==1.16.0
 smmap==4.0.0
-streamlit==1.0.0
+streamlit==1.11.1
 terminado==0.12.1
 testpath==0.5.0
 toml==0.10.2

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -38,7 +38,7 @@ nbconvert==6.2.0
 nbformat==5.1.3
 nest-asyncio==1.5.1
 notebook==6.4.12
-numpy==1.21.2
+numpy==1.22.0
 packaging==21.0
 pandas==1.3.3
 pandocfilters==1.5.0

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -32,7 +32,7 @@ jupyterlab-pygments==0.1.2
 jupyterlab-widgets==1.0.2
 MarkupSafe==2.0.1
 matplotlib-inline==0.1.3
-mistune==0.8.4
+mistune==2.0.3
 nbclient==0.5.4
 nbconvert==6.2.0
 nbformat==5.1.3


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump streamlit from 1.0.0 to 1.11.1 in /streamlit-income-share (#70) @dependabot
* Bump mistune from 0.8.4 to 2.0.3 in /jupyter-interactive-visualization (#69) @dependabot
* Bump mistune from 0.8.4 to 2.0.3 in /streamlit-income-share (#68) @dependabot
* Bump mistune from 0.8.4 to 2.0.3 in /jupyter-static-visualization (#67) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /streamlit-income-share (#66) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /sentiment-analysis-app (#65) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /dash-bikeshare (#64) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /flask-sentiment-analysis-api (#63) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /dash-app (#62) @dependabot
* Bump numpy from 1.21.0 to 1.22.0 in /fastapi-stock (#61) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /flask-restx (#60) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /image-classifier (#59) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /rmarkdown-notebook (#58) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /jupyter-static-visualization (#57) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /rmarkdown-static-visualization (#56) @dependabot
* Bump numpy from 1.21.2 to 1.22.0 in /jupyter-interactive-visualization (#55) @dependabot
