### PR TITLE
Change --index-url to a specific date for jupyter-interactive-visualization

### DIFF
--- a/jupyter-interactive-visualization/requirements.txt
+++ b/jupyter-interactive-visualization/requirements.txt
@@ -1,4 +1,4 @@
---index-url https://packagemanager.rstudio.com/pypi/latest/simple
+--index-url https://packagemanager.rstudio.com/pypi/2022-09-13/simple
 jupyter
 numpy
 bokeh


### PR DESCRIPTION
This fixes an issue trying to deploy jupyter-interactive-visualization to Connect from git. Also makes it more predictable going forward.