### PR TITLE
remove pandas version lock

### DIFF
--- a/dash-app/requirements.txt
+++ b/dash-app/requirements.txt
@@ -1,4 +1,3 @@
---index-url https://packagemanager.rstudio.com/pypi/latest/simple
 Brotli==1.0.9
 click==8.0.1
 dash==2.0.0
@@ -11,7 +10,7 @@ itsdangerous==2.0.1
 Jinja2==3.0.2
 MarkupSafe==2.0.1
 numpy==1.22.0
-pandas==1.3.3
+pandas==1.5.2
 plotly==5.3.1
 python-dateutil==2.8.2
 python-dotenv==0.19.0

--- a/fastapi-stock/requirements.txt
+++ b/fastapi-stock/requirements.txt
@@ -4,7 +4,7 @@ click==8.0.1
 fastapi==0.66.0
 h11==0.12.0
 numpy==1.22.0
-pandas==1.3.0
+pandas
 pydantic==1.8.2
 python-dateutil==2.8.2
 pytz==2021.1

--- a/fastapi-stock/requirements.txt
+++ b/fastapi-stock/requirements.txt
@@ -1,14 +1,16 @@
---index-url https://packagemanager.rstudio.com/pypi/latest/simple
-asgiref==3.4.1
-click==8.0.1
-fastapi==0.66.0
-h11==0.12.0
+anyio==3.6.2
+asgiref==3.6.0
+click==8.1.3
+fastapi==0.89.1
+h11==0.14.0
+idna==3.4
 numpy==1.22.0
-pandas
-pydantic==1.8.2
+pandas==1.5.2
+pydantic==1.10.4
 python-dateutil==2.8.2
-pytz==2021.1
+pytz==2022.7
 six==1.16.0
-starlette==0.14.2
-typing-extensions==3.10.0.0
-uvicorn==0.14.0
+sniffio==1.3.0
+starlette==0.22.0
+typing_extensions==4.4.0
+uvicorn==0.20.0


### PR DESCRIPTION
Pandas 1.3 has a dependency on numpy 1.17.
numpy 1.17 only works with python versions 3.5-3.7. We do not have those versions of python installed on colorado on the latest session images.
So removing the version lock on pandas 1.3 and installing the latest pandas version works to deploy the app