### PR TITLE
Combined dependencies PR

### DIFF
--- a/dash-bikeshare/requirements.txt
+++ b/dash-bikeshare/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 click==8.1.3
 dash==2.9.1

--- a/dash-bikeshare/requirements.txt
+++ b/dash-bikeshare/requirements.txt
@@ -19,5 +19,5 @@ pytz==2022.7.1
 requests==2.31.0
 six==1.16.0
 tenacity==8.2.2
-urllib3==1.26.15
+urllib3==1.26.18
 Werkzeug==2.2.3

--- a/flask-sentiment-analysis-api/requirements.txt
+++ b/flask-sentiment-analysis-api/requirements.txt
@@ -18,6 +18,6 @@ spacy==2.3.9
 srsly==1.0.6
 thinc==7.4.6
 tqdm==4.65.0
-urllib3==1.26.15
+urllib3==1.26.18
 wasabi==0.10.1
 Werkzeug==2.2.3

--- a/flask-sentiment-analysis-api/requirements.txt
+++ b/flask-sentiment-analysis-api/requirements.txt
@@ -1,6 +1,6 @@
 blis==0.7.9
 catalogue==1.0.2
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 click==8.1.3
 cymem==2.0.7

--- a/flask-sentiment-analysis-app/requirements.txt
+++ b/flask-sentiment-analysis-app/requirements.txt
@@ -18,6 +18,6 @@ spacy==2.3.9
 srsly==1.0.6
 thinc==7.4.6
 tqdm==4.65.0
-urllib3==1.26.15
+urllib3==1.26.18
 wasabi==0.10.1
 Werkzeug==2.2.3

--- a/flask-sentiment-analysis-app/requirements.txt
+++ b/flask-sentiment-analysis-app/requirements.txt
@@ -1,6 +1,6 @@
 blis==0.7.9
 catalogue==1.0.2
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 click==8.1.3
 cymem==2.0.7

--- a/jupyter-interactive-visualization/requirements.txt
+++ b/jupyter-interactive-visualization/requirements.txt
@@ -54,7 +54,7 @@ pandocfilters==1.5.0
 parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==9.4.0
+Pillow==10.0.1
 platformdirs==3.1.1
 plotly==5.13.1
 prometheus-client==0.16.0

--- a/jupyter-interactive-visualization/requirements.txt
+++ b/jupyter-interactive-visualization/requirements.txt
@@ -82,7 +82,7 @@ stack-data==0.6.2
 tenacity==8.2.2
 terminado==0.17.1
 tinycss2==1.2.1
-tornado==6.3.2
+tornado==6.3.3
 traitlets==5.9.0
 uri-template==1.2.0
 wcwidth==0.2.6

--- a/jupyter-interactive-visualization/requirements.txt
+++ b/jupyter-interactive-visualization/requirements.txt
@@ -33,7 +33,7 @@ jupyter-console==6.6.3
 jupyter-events==0.6.3
 jupyter_client==8.1.0
 jupyter_core==5.3.0
-jupyter_server==2.5.0
+jupyter_server==2.7.2
 jupyter_server_terminals==0.4.4
 jupyterlab-pygments==0.2.2
 jupyterlab-widgets==3.0.6

--- a/jupyter-interactive-visualization/requirements.txt
+++ b/jupyter-interactive-visualization/requirements.txt
@@ -63,7 +63,7 @@ psutil==5.9.4
 ptyprocess==0.7.0
 pure-eval==0.2.2
 pycparser==2.21
-Pygments==2.14.0
+Pygments==2.15.0
 pyrsistent==0.19.3
 python-dateutil==2.8.2
 python-json-logger==2.0.7

--- a/jupyter-voila/requirements.txt
+++ b/jupyter-voila/requirements.txt
@@ -92,7 +92,7 @@ tinycss2==1.2.1
 tornado==6.3.2
 traitlets==5.9.0
 traittypes==0.2.1
-urllib3==1.26.15
+urllib3==1.26.18
 voila==0.4.0
 wcwidth==0.2.6
 webencodings==0.5.1

--- a/jupyter-voila/requirements.txt
+++ b/jupyter-voila/requirements.txt
@@ -63,7 +63,7 @@ pandocfilters==1.5.0
 parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==9.4.0
+Pillow==10.0.1
 platformdirs==3.1.1
 prometheus-client==0.16.0
 prompt-toolkit==3.0.38

--- a/jupyter-voila/requirements.txt
+++ b/jupyter-voila/requirements.txt
@@ -71,7 +71,7 @@ psutil==5.9.4
 ptyprocess==0.7.0
 pure-eval==0.2.2
 pycparser==2.21
-Pygments==2.14.0
+Pygments==2.15.0
 pyparsing==3.0.9
 pyrsistent==0.19.3
 python-dateutil==2.8.2

--- a/jupyter-voila/requirements.txt
+++ b/jupyter-voila/requirements.txt
@@ -9,7 +9,7 @@ backcall==0.2.0
 beautifulsoup4==4.12.0
 bleach==6.0.0
 bqplot==0.12.36
-certifi==2022.12.7
+certifi==2023.7.22
 cffi==1.15.1
 charset-normalizer==3.1.0
 comm==0.1.2

--- a/jupyter-voila/requirements.txt
+++ b/jupyter-voila/requirements.txt
@@ -89,7 +89,7 @@ soupsieve==2.4
 stack-data==0.6.2
 terminado==0.17.1
 tinycss2==1.2.1
-tornado==6.3.2
+tornado==6.3.3
 traitlets==5.9.0
 traittypes==0.2.1
 urllib3==1.26.18

--- a/jupyter-voila/requirements.txt
+++ b/jupyter-voila/requirements.txt
@@ -38,7 +38,7 @@ json5==0.9.11
 jsonschema==4.17.3
 jupyter==1.0.0
 jupyter-console==6.6.3
-jupyter-server==1.23.6
+jupyter-server==2.7.2
 jupyter_client==7.4.1
 jupyter_core==5.3.0
 jupyterlab-pygments==0.2.2

--- a/quarto-lightbox/requirements.txt
+++ b/quarto-lightbox/requirements.txt
@@ -27,7 +27,7 @@ Jinja2==3.1.2
 jsonschema==4.17.0
 jupyter==1.0.0
 jupyter-console==6.4.4
-jupyter-server==1.23.0
+jupyter-server==2.7.2
 jupyter_client==7.4.4
 jupyter_core==4.11.2
 jupyterlab-pygments==0.2.2

--- a/quarto-lightbox/requirements.txt
+++ b/quarto-lightbox/requirements.txt
@@ -57,7 +57,7 @@ psutil==5.9.3
 ptyprocess==0.7.0
 pure-eval==0.2.2
 pycparser==2.21
-Pygments==2.13.0
+Pygments==2.15.0
 PyJWT==2.6.0
 pyparsing==3.0.9
 pyrsistent==0.19.2

--- a/quarto-lightbox/requirements.txt
+++ b/quarto-lightbox/requirements.txt
@@ -74,7 +74,7 @@ soupsieve==2.3.2.post1
 stack-data==0.6.0
 terminado==0.17.0
 tinycss2==1.2.1
-tornado==6.3.2
+tornado==6.3.3
 traitlets==5.5.0
 wcwidth==0.2.5
 webencodings==0.5.1

--- a/quarto-lightbox/requirements.txt
+++ b/quarto-lightbox/requirements.txt
@@ -50,7 +50,7 @@ pandocfilters==1.5.0
 parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==9.3.0
+Pillow==10.0.1
 prometheus-client==0.15.0
 prompt-toolkit==3.0.32
 psutil==5.9.3

--- a/reticulated-image-classifier/requirements.txt
+++ b/reticulated-image-classifier/requirements.txt
@@ -13,4 +13,4 @@ sympy==1.11.1
 torch==2.0.0
 torchvision==0.15.1
 typing_extensions==4.5.0
-urllib3==1.26.15
+urllib3==1.26.18

--- a/reticulated-image-classifier/requirements.txt
+++ b/reticulated-image-classifier/requirements.txt
@@ -7,7 +7,7 @@ MarkupSafe==2.1.2
 mpmath==1.3.0
 networkx==3.0
 numpy==1.24.2
-Pillow==9.4.0
+Pillow==10.0.1
 requests==2.31.0
 sympy==1.11.1
 torch==2.0.0

--- a/reticulated-image-classifier/requirements.txt
+++ b/reticulated-image-classifier/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 filelock==3.10.0
 idna==3.4

--- a/reticulated-sentiment-analysis-app/requirements.txt
+++ b/reticulated-sentiment-analysis-app/requirements.txt
@@ -14,5 +14,5 @@ spacy==2.3.7
 srsly==1.0.5
 thinc==7.4.5
 tqdm==4.62.3
-urllib3==1.26.7
+urllib3==2.0.6
 wasabi==0.8.2

--- a/reticulated-sentiment-analysis-app/requirements.txt
+++ b/reticulated-sentiment-analysis-app/requirements.txt
@@ -1,7 +1,7 @@
 --index-url https://packagemanager.rstudio.com/pypi/latest/simple
 blis==0.7.4
 catalogue==1.0.0
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==2.0.6
 cymem==2.0.5
 idna==3.2

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 decorator==5.1.1
 entrypoints==0.4
 gitdb==4.0.10
-GitPython==3.1.31
+GitPython==3.1.37
 idna==3.4
 importlib-metadata==6.1.0
 Jinja2==3.1.2

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -41,6 +41,6 @@ tornado==6.3.2
 typing_extensions==4.5.0
 tzdata==2022.7
 tzlocal==4.3
-urllib3==1.26.15
+urllib3==1.26.18
 validators==0.20.0
 zipp==3.15.0

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -2,7 +2,7 @@ altair==4.2.2
 attrs==22.2.0
 blinker==1.5
 cachetools==5.3.0
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 click==8.1.3
 decorator==5.1.1

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -37,7 +37,7 @@ smmap==5.0.0
 streamlit==1.20.0
 toml==0.10.2
 toolz==0.12.0
-tornado==6.3.2
+tornado==6.3.3
 typing_extensions==4.5.0
 tzdata==2022.7
 tzlocal==4.3

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -19,7 +19,7 @@ mdurl==0.1.2
 numpy==1.24.2
 packaging==23.0
 pandas==1.5.3
-Pillow==9.4.0
+Pillow==10.0.1
 protobuf==3.20.3
 pyarrow==11.0.0
 pydeck==0.8.0

--- a/streamlit-income-share/requirements.txt
+++ b/streamlit-income-share/requirements.txt
@@ -23,7 +23,7 @@ Pillow==10.0.1
 protobuf==3.20.3
 pyarrow==11.0.0
 pydeck==0.8.0
-Pygments==2.14.0
+Pygments==2.15.0
 Pympler==1.0.1
 pyrsistent==0.19.3
 python-dateutil==2.8.2


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump urllib3 from 1.26.7 to 2.0.6 in /reticulated-sentiment-analysis-app (#178) @app/dependabot
* Bump urllib3 from 1.26.15 to 1.26.18 in /dash-bikeshare (#177) @app/dependabot
* Bump urllib3 from 1.26.15 to 1.26.18 in /reticulated-image-classifier (#176) @app/dependabot
* Bump urllib3 from 1.26.15 to 1.26.18 in /streamlit-income-share (#175) @app/dependabot
* Bump urllib3 from 1.26.15 to 1.26.18 in /flask-sentiment-analysis-app (#174) @app/dependabot
* Bump urllib3 from 1.26.15 to 1.26.18 in /flask-sentiment-analysis-api (#172) @app/dependabot
* Bump urllib3 from 1.26.15 to 1.26.18 in /jupyter-voila (#173) @app/dependabot
* Bump gitpython from 3.1.31 to 3.1.37 in /streamlit-income-share (#171) @app/dependabot
* Bump pillow from 9.4.0 to 10.0.1 in /reticulated-image-classifier (#169) @app/dependabot
* Bump pillow from 9.4.0 to 10.0.1 in /jupyter-interactive-visualization (#170) @app/dependabot
* Bump pillow from 9.4.0 to 10.0.1 in /jupyter-voila (#168) @app/dependabot
* Bump pillow from 9.4.0 to 10.0.1 in /streamlit-income-share (#167) @app/dependabot
* Bump pillow from 9.3.0 to 10.0.1 in /quarto-lightbox (#166) @app/dependabot
* Bump jupyter-server from 2.5.0 to 2.7.2 in /jupyter-interactive-visualization (#156) @app/dependabot
* Bump jupyter-server from 1.23.6 to 2.7.2 in /jupyter-voila (#155) @app/dependabot
* Bump jupyter-server from 1.23.0 to 2.7.2 in /quarto-lightbox (#154) @app/dependabot
* Bump tornado from 6.3.2 to 6.3.3 in /quarto-lightbox (#153) @app/dependabot
* Bump tornado from 6.3.2 to 6.3.3 in /jupyter-voila (#152) @app/dependabot
* Bump tornado from 6.3.2 to 6.3.3 in /jupyter-interactive-visualization (#151) @app/dependabot
* Bump tornado from 6.3.2 to 6.3.3 in /streamlit-income-share (#150) @app/dependabot
* Bump certifi from 2022.12.7 to 2023.7.22 in /reticulated-sentiment-analysis-app (#147) @app/dependabot
* Bump certifi from 2022.12.7 to 2023.7.22 in /jupyter-voila (#145) @app/dependabot
* Bump certifi from 2022.12.7 to 2023.7.22 in /streamlit-income-share (#146) @app/dependabot
* Bump certifi from 2022.12.7 to 2023.7.22 in /reticulated-image-classifier (#144) @app/dependabot
* Bump certifi from 2022.12.7 to 2023.7.22 in /flask-sentiment-analysis-api (#143) @app/dependabot
* Bump certifi from 2022.12.7 to 2023.7.22 in /dash-bikeshare (#142) @app/dependabot
* Bump certifi from 2022.12.7 to 2023.7.22 in /flask-sentiment-analysis-app (#141) @app/dependabot
* Bump pygments from 2.14.0 to 2.15.0 in /jupyter-voila (#140) @app/dependabot
* Bump pygments from 2.14.0 to 2.15.0 in /streamlit-income-share (#139) @app/dependabot
* Bump pygments from 2.14.0 to 2.15.0 in /jupyter-interactive-visualization (#138) @app/dependabot
* Bump pygments from 2.13.0 to 2.15.0 in /quarto-lightbox (#137) @app/dependabot
