### PR TITLE
Add load_dotenv explicitly to dash apps

### DIFF
--- a/dash-app/app.py
+++ b/dash-app/app.py
@@ -1,3 +1,5 @@
+from dotenv import load_dotenv
+load_dotenv()
 import dash
 import pandas as pd
 from dash import dcc, html

--- a/dash-bikeshare/app.py
+++ b/dash-bikeshare/app.py
@@ -1,3 +1,5 @@
+from dotenv import load_dotenv
+load_dotenv()
 import dash
 import os
 import pandas as pd
@@ -6,7 +8,6 @@ import requests as req
 
 from dash import dcc, html
 from dash.dependencies import Input, Output
-from dotenv import load_dotenv
 
 app = dash.Dash(__name__)
 

--- a/dash-stock-pricing/app.py
+++ b/dash-stock-pricing/app.py
@@ -444,4 +444,4 @@ def update_scatter_plot(all_tickers, price):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run()

--- a/dash-stock-pricing/app.py
+++ b/dash-stock-pricing/app.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from dotenv import load_dotenv
+load_dotenv()
 import os
 
 import dash


### PR DESCRIPTION
This PR will explicitly add `load_dotenv(), which should make running it more reliable.
Closes https://github.com/sol-eng/python-examples/issues/194