### PR TITLE
Add anywidget for altair graph to work

### DIFF
--- a/shiny-income-share/requirements.txt
+++ b/shiny-income-share/requirements.txt
@@ -1,4 +1,5 @@
 --index-url https://p3m.dev/pypi/2022-12-09/simple
+anywidget
 shiny
 shinywidgets
 vega

--- a/shiny-income-share/requirements.txt
+++ b/shiny-income-share/requirements.txt
@@ -1,4 +1,4 @@
---index-url https://p3m.dev/pypi/2022-12-09/simple
+--index-url https://p3m.dev/pypi/2023-12-05/simple
 anywidget
 shiny
 shinywidgets


### PR DESCRIPTION
When running `shiny-income-share` I see the following. Installing `anywidget` fixes the issue.

![image](https://github.com/sol-eng/python-examples/assets/180123/77dcaf0f-a763-4bd9-8f07-ab99928e770d)

Closes https://github.com/sol-eng/python-examples/issues/199